### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "laravel/framework": "^5.3"
+        "laravel/framework": "5.3.* || 5.4.* || 5.5.*"
     },
     "require-dev": {
         "mockery/mockery": "~0.9.4",


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.